### PR TITLE
[TM-359] Initial repo setup

### DIFF
--- a/.buildkite/check-trailing-whitespace.sh
+++ b/.buildkite/check-trailing-whitespace.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+files=$(git ls-files -- . ':!:*.patch' | xargs grep --files-with-matches --binary-files=without-match '[[:blank:]]$')
+if [[ ! -z $files ]];then
+  echo '  Files with trailing whitespace found:'
+  for f in "${files[@]}"; do
+    echo "  * $f"
+  done
+  exit 1
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+env:
+  NIX_PATH: nixpkgs=channel:nixos-unstable
+
+steps:
+ - command: nix run nixpkgs.reuse -c reuse lint
+   label: reuse lint
+ - command: .buildkite/check-trailing-whitespace.sh
+   label: check trailing whitespace
+ - command: "nix run -f https://github.com/serokell/crossref-verifier/archive/master.tar.gz -c crossref-verify"
+   label: crossref-verify
+   soft_fail: true
+ - commands:
+   - nix-build -A tezos-client-static -o tezos-client-static
+   - nix-build -A tezos-client-rpm-package -o tezos-client-rpm
+   - nix-build -A tezos-client-deb-package -o tezos-client-deb
+   label: build and package
+   artifact_paths:
+     - ./tezos-client-static/bin/tezos-client
+     - ./tezos-client-rpm/*
+     - ./tezos-client-deb/*

--- a/.crossref-verifier.yaml
+++ b/.crossref-verifier.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# Parameters of repository traversal.
+traversal:
+  # Folders which we pretend do not exist
+  # (so they are neither analyzed nor can be referenced).
+  ignored:
+    # Git files
+    - .git
+
+# Verification parameters.
+verification:
+  # On 'anchor not found' error, how much similar anchors should be displayed as hint.
+  # Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
+  # File prefixes, references in which should not be analyzed.
+  notScanned:
+    # Github-specific files
+    - .github/pull_request_template.md
+
+  # Glob patterns describing the files which do not physically exist in the repository
+  # but should be treated as existing nevertheless.
+  virtualFiles:
+    # Github pages
+    - ../../issues
+    - ../../issues/*
+    - ../../pulls
+    - ../../pulls/*

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contribution Guidelines
+
+## Reporting Issues
+
+Please [open an issue](https://github.com/serokell/tezos-client/issues/new)
+if you find a bug or have a feature request.
+Before submitting a bug report or feature request, check to make sure it hasn't already been submitted
+
+The more detailed your report is, the faster it can be resolved.
+If you report a bug, please provide steps to reproduce this bug and revision of code in which this bug reproduces.
+
+
+## Code
+
+If you would like to contribute code to fix a bug, add a new feature, or
+otherwise improve our project, pull requests are most welcome.
+
+## Legal
+
+We want to make sure that our projects come with correct licensing information
+and that this information is machine-readable, thus we are following the
+[REUSE Practices][reuse] – feel free to click the link and read about them,
+but, basically, it all boils down to the following:
+
+  * Add the following header at the very top (but below the shebang, if there
+    is one) of each source file in the repository (yes, each and every source
+    file – it is not as hard as it might sound):
+
+    ```
+    # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+    #
+    # SPDX-License-Identifier: MPL-2.0
+    ```
+
+    (This is an example for Nix; adapt it as needed for other languages.)
+
+    The license identifier should be the same as the one in the `LICENSE` file.
+
+  * If you are copying any source files from some other project, and they do not
+    contain a header with a copyright and a machine-readable license identifier,
+    add it, but be extra careful and make sure that information you are recording
+    is correct.
+
+    If the license of the file is different from the one used in the project and
+    you do not plan to relicense it, use the appropriate license identifier and
+    make sure the license text exists in the `LICENSES` directory.
+
+    If the file contains the entire license in its header, it is best to move the
+    text to a separate file in the `LICENSES` directory and leave a reference.
+
+  * If you are copying pieces of code from some other project, leave a note in the
+    comments, stating where you copied it from, who is the copyright owner, and
+    what license applies.
+
+  * All the same rules apply to documentation that is stored in the repository.
+
+These simple rules should cover most of situation you are likely to encounter.
+In case of doubt, consult the [REUSE Practices][reuse] document.
+
+[reuse]: https://reuse.software/spec/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+
+<!--
+Describes the nature of your changes. If they are substantial, you should
+further subdivide this into a section describing the problem you are solving and
+another describing your solution.
+-->
+
+## Related issue(s)
+
+<!--
+- Short description of how the PR relates to the issue, including an issue link.
+For example
+- Fixed #100500 by adding lenses to exported items
+
+Write 'None' if there are no related issues (which is discouraged).
+-->
+https://github.com/serokell/tezos-client/issues/
+
+#### Related changes (conditional)
+
+- [ ] I checked whether I should update the [README](../tree/master/README.md)
+
+#### Stylistic guide (mandatory)
+
+- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: .github/pull_request_template.md
+Copyright: TQ Tezos <https://tqtezos.com>
+License: MPL-2.0

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,312 @@
+Mozilla Public License Version 2.0
+
+   1. Definitions
+
+1.1. "Contributor" means each individual or legal entity that creates, contributes
+to the creation of, or owns Covered Software.
+
+1.2. "Contributor Version" means the combination of the Contributions of others
+(if any) used by a Contributor and that particular Contributor's Contribution.
+
+      1.3. "Contribution" means Covered Software of a particular Contributor.
+
+1.4. "Covered Software" means Source Code Form to which the initial Contributor
+has attached the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case including portions
+thereof.
+
+      1.5. "Incompatible With Secondary Licenses" means
+
+(a) that the initial Contributor has attached the notice described in Exhibit
+B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of version
+1.1 or earlier of the License, but not also under the terms of a Secondary
+License.
+
+1.6. "Executable Form" means any form of the work other than Source Code Form.
+
+1.7. "Larger Work" means a work that combines Covered Software with other
+material, in a separate file or files, that is not Covered Software.
+
+      1.8. "License" means this document.
+
+1.9. "Licensable" means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and all of the
+rights conveyed by this License.
+
+      1.10. "Modifications" means any of the following:
+
+(a) any file in Source Code Form that results from an addition to, deletion
+from, or modification of the contents of Covered Software; or
+
+(b) any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor means any patent claim(s), including
+without limitation, method, process, and apparatus claims, in any patent Licensable
+by such Contributor that would be infringed, but for the grant of the License,
+by the making, using, selling, offering for sale, having made, import, or
+transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License" means either the GNU General Public License, Version
+2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form" means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your") means an individual or a legal entity exercising rights
+under this License. For legal entities, "You" includes any entity that controls,
+is controlled by, or is under common control with You. For purposes of this
+definition, "control" means (a) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or otherwise,
+or (b) ownership of more than fifty percent (50%) of the outstanding shares
+or beneficial ownership of such entity.
+
+   2. License Grants and Conditions
+
+      2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+license:
+
+(a) under intellectual property rights (other than patent or trademark) Licensable
+by such Contributor to use, reproduce, make available, modify, display, perform,
+distribute, and otherwise exploit its Contributions, either on an unmodified
+basis, with Modifications, or as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer for
+sale, have made, import, and otherwise transfer either its Contributions or
+its Contributor Version.
+
+      2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become
+effective for each Contribution on the date the Contributor first distributes
+such Contribution.
+
+      2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this
+License. No additional rights or licenses will be implied from the distribution
+or licensing of Covered Software under this License. Notwithstanding Section
+2.1(b) above, no patent license is granted by a Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software; or
+
+(b) for infringements caused by: (i) Your and any other third party's modifications
+of Covered Software, or (ii) the combination of its Contributions with other
+software (except as part of its Contributor Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of its
+Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or
+logos of any Contributor (except as may be necessary to comply with the notice
+requirements in Section 3.4).
+
+      2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to distribute
+the Covered Software under a subsequent version of this License (see Section
+10.2) or under the terms of a Secondary License (if permitted under the terms
+of Section 3.3).
+
+      2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions
+are its original creation(s) or it has sufficient rights to grant the rights
+to its Contributions conveyed by this License.
+
+      2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable
+copyright doctrines of fair use, fair dealing, or other equivalents.
+
+      2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+Section 2.1.
+
+   3. Responsibilities
+
+      3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any Modifications
+that You create or to which You contribute, must be under the terms of this
+License. You must inform recipients that the Source Code Form of the Covered
+Software is governed by the terms of this License, and how they can obtain
+a copy of this License. You may not attempt to alter or restrict the recipients'
+rights in the Source Code Form.
+
+      3.2. Distribution of Executable Form
+
+      If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code Form,
+as described in Section 3.1, and You must inform recipients of the Executable
+Form how they can obtain a copy of such Source Code Form by reasonable means
+in a timely manner, at a charge no more than the cost of distribution to the
+recipient; and
+
+(b) You may distribute such Executable Form under the terms of this License,
+or sublicense it under different terms, provided that the license for the
+Executable Form does not attempt to limit or alter the recipients' rights
+in the Source Code Form under this License.
+
+      3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice, provided
+that You also comply with the requirements of this License for the Covered
+Software. If the Larger Work is a combination of Covered Software with a work
+governed by one or more Secondary Licenses, and the Covered Software is not
+Incompatible With Secondary Licenses, this License permits You to additionally
+distribute such Covered Software under the terms of such Secondary License(s),
+so that the recipient of the Larger Work may, at their option, further distribute
+the Covered Software under the terms of either this License or such Secondary
+License(s).
+
+      3.4. Notices
+
+You may not remove or alter the substance of any license notices (including
+copyright notices, patent notices, disclaimers of warranty, or limitations
+of liability) contained within the Source Code Form of the Covered Software,
+except that You may alter any license notices to the extent required to remedy
+known factual inaccuracies.
+
+      3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity
+or liability obligations to one or more recipients of Covered Software. However,
+You may do so only on Your own behalf, and not on behalf of any Contributor.
+You must make it absolutely clear that any such warranty, support, indemnity,
+or liability obligation is offered by You alone, and You hereby agree to indemnify
+every Contributor for any liability incurred by such Contributor as a result
+of warranty, support, indemnity or liability terms You offer. You may include
+additional disclaimers of warranty and limitations of liability specific to
+any jurisdiction.
+
+   4. Inability to Comply Due to Statute or Regulation
+
+If it is impossible for You to comply with any of the terms of this License
+with respect to some or all of the Covered Software due to statute, judicial
+order, or regulation then You must: (a) comply with the terms of this License
+to the maximum extent possible; and (b) describe the limitations and the code
+they affect. Such description must be placed in a text file included with
+all distributions of the Covered Software under this License. Except to the
+extent prohibited by statute or regulation, such description must be sufficiently
+detailed for a recipient of ordinary skill to be able to understand it.
+
+   5. Termination
+
+5.1. The rights granted under this License will terminate automatically if
+You fail to comply with any of its terms. However, if You become compliant,
+then the rights granted under this License from a particular Contributor are
+reinstated (a) provisionally, unless and until such Contributor explicitly
+and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor
+fails to notify You of the non-compliance by some reasonable means prior to
+60 days after You have come back into compliance. Moreover, Your grants from
+a particular Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the first
+time You have received notice of non-compliance with this License from such
+Contributor, and You become compliant prior to 30 days after Your receipt
+of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent infringement
+claim (excluding declaratory judgment actions, counter-claims, and cross-claims)
+alleging that a Contributor Version directly or indirectly infringes any patent,
+then the rights granted to You by any and all Contributors for the Covered
+Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end
+user license agreements (excluding distributors and resellers) which have
+been validly granted by You or Your distributors under this License prior
+to termination shall survive termination.
+
+   6. Disclaimer of Warranty
+
+Covered Software is provided under this License on an "as is" basis, without
+warranty of any kind, either expressed, implied, or statutory, including,
+without limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing. The entire risk
+as to the quality and performance of the Covered Software is with You. Should
+any Covered Software prove defective in any respect, You (not any Contributor)
+assume the cost of any necessary servicing, repair, or correction. This disclaimer
+of warranty constitutes an essential part of this License. No use of any Covered
+Software is authorized under this License except under this disclaimer.
+
+   7. Limitation of Liability
+
+Under no circumstances and under no legal theory, whether tort (including
+negligence), contract, or otherwise, shall any Contributor, or anyone who
+distributes Covered Software as permitted above, be liable to You for any
+direct, indirect, special, incidental, or consequential damages of any character
+including, without limitation, damages for lost profits, loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses, even if such party shall have been informed of the possibility
+of such damages. This limitation of liability shall not apply to liability
+for death or personal injury resulting from such party's negligence to the
+extent applicable law prohibits such limitation. Some jurisdictions do not
+allow the exclusion or limitation of incidental or consequential damages,
+so this exclusion and limitation may not apply to You.
+
+   8. Litigation
+
+Any litigation relating to this License may be brought only in the courts
+of a jurisdiction where the defendant maintains its principal place of business
+and such litigation shall be governed by laws of that jurisdiction, without
+reference to its conflict-of-law provisions. Nothing in this Section shall
+prevent a party's ability to bring cross-claims or counter-claims.
+
+   9. Miscellaneous
+
+This License represents the complete agreement concerning the subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it enforceable.
+Any law or regulation which provides that the language of a contract shall
+be construed against the drafter shall not be used to construe this License
+against a Contributor.
+
+   10. Versions of the License
+
+      10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3,
+no one other than the license steward has the right to modify or publish new
+versions of this License. Each version will be given a distinguishing version
+number.
+
+      10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of
+the License under which You originally received the Covered Software, or under
+the terms of any subsequent version published by the license steward.
+
+      10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create
+a new license for such software, you may create and use a modified version
+of this License if you rename the license and remove any references to the
+name of the license steward (except to note that such modified license differs
+from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With Secondary
+Licenses under the terms of this version of the License, the notice described
+in Exhibit B of this License must be attached. Exhibit A - Source Code Form
+License Notice
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined
+by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # `tezos-client`
 
+[![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg)](https://buildkite.com/serokell/tezos-client)
+
 `tezos-client` is CLI tool used for interaction with Tezos blockchain.
 This repo contains nix expression for building staticically linked
 tezos-client binaries that can be used with remote tezos nodes without
@@ -18,6 +20,12 @@ to build staticically linked `tezos-client` executable.
 
 Run `nix-build -A tezos-client-{rpm, deb}-package -o tezos-client-package` in order
 to build native `.rpm` or `.deb` package for RedHat and Debiab-based distros.
+
+## Obtain binary or packages from CI
+
+If you don't want to build these files from scratch, you can download artifacts
+produced by the CI. Go to the [master builds](https://buildkite.com/serokell/tezos-client/builds?branch=master)
+and download the artifacts from the `build and package` stage.
 
 ## `tezos-client` usage
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# tezos-client
+<!--
+   - SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+   -
+   - SPDX-License-Identifier: MPL-2.0
+   -->
+
+# `tezos-client`
+
+`tezos-client` is CLI tool used for interaction with Tezos blockchain.
+This repo contains nix expression for building staticically linked
+tezos-client binaries that can be used with remote tezos nodes without
+using `babylonnet.sh` or `mainnet.sh` scripts.
+
+## Build Instructions
+
+Run `nix-build -A tezos-client-static -o tezos-static`
+to build staticically linked `tezos-client` executable.
+
+Run `nix-build -A tezos-client-{rpm, deb}-package -o tezos-client-package` in order
+to build native `.rpm` or `.deb` package for RedHat and Debiab-based distros.
+
+## `tezos-client` usage
+
+Run `tezos-client [global options] command [command options]`.
+
+Run `tezos-client man` to get more information.
+
+## For Contributors
+
+Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more information.
+
+## About Serokell
+
+This repository is maintained and funded with ❤️ by [Serokell](https://serokell.io/).
+The names and logo for Serokell are trademark of Serokell OÜ.
+
+We love open source software! See [our other projects](https://serokell.io/community?utm_source=github) or [hire us](https://serokell.io/hire-us?utm_source=github) to design, develop and grow your idea!

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+
+let
+  root = ./.;
+  tezos-client-static = import ./nix/static.nix;
+  tezos-client-binary = "${tezos-client-static}/bin/tezos-client";
+  packageDesc = {
+    project = "tezos-client";
+    majorVersion = "1";
+    minorVersion = "0";
+    packageRevision = "0";
+    bin = tezos-client-binary;
+    arch = "amd64";
+    license = "MPL-2.0";
+    dependencies = "";
+    maintainer = "Serokell https://serokell.io";
+    licenseFile = "${root}/LICENSES/MPL-2.0.txt";
+    description = "CLI client for interacting with tezos blockchain";
+  };
+  buildDeb =
+    import ./packageDeb.nix { inherit stdenv writeTextFile; } packageDesc;
+  buildRpm = import ./packageRpm.nix { inherit stdenv writeTextFile; }
+    (packageDesc // { arch = "x86_64"; });
+
+  inherit (vmTools)
+    makeImageFromDebDist makeImageFromRPMDist debDistros rpmDistros
+    runInLinuxImage;
+  ubuntuImage = makeImageFromDebDist debDistros.ubuntu1804x86_64;
+  fedoraImage = makeImageFromRPMDist rpmDistros.fedora27x86_64;
+  tezos-client-rpm-package =
+    runInLinuxImage (buildRpm.packageRpm // { diskImage = fedoraImage; });
+
+  tezos-client-deb-package =
+    runInLinuxImage (buildDeb.packageDeb // { diskImage = ubuntuImage; });
+
+in rec {
+  inherit tezos-client-static tezos-client-rpm-package tezos-client-deb-package;
+
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ pkgs ? import <nixpkgs> { } }:
+let
+  oca = pkgs.ocaml-ng.ocamlPackages_4_07.overrideScope' (self: super: {
+    bigstring = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, base }:
+
+        buildDunePackage rec {
+          pname = "bigstring";
+          version = "0.2";
+
+          minimumOCamlVersion = "4.03";
+
+          src = fetchFromGitHub {
+            owner = "c-cube";
+            repo = "ocaml-${pname}";
+            rev = version;
+            sha256 = "0ypdf29cmwmjm3djr5ygz8ls81dl41a4iz1xx5gbcdpbrdiapb77";
+          };
+
+          buildInputs = [ base ];
+          doCheck = true;
+        }) { };
+    nonstd = self.callPackage ({ stdenv, fetchgit, buildDunePackage, base }:
+
+      buildDunePackage rec {
+        pname = "nonstd";
+        version = "0.0.3";
+
+        minimumOCamlVersion = "4.03";
+
+        src = fetchgit {
+          url = "https://bitbucket.org/smondet/nonstd.git";
+          rev = "${pname}.${version}";
+          sha256 = "0ccjwcriwm8fv29ij1cnbc9win054kb6pfga3ygzdbjpjb778j46";
+        };
+        #doCheck = true;
+      }) { };
+    sosa = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, ocamlbuild }:
+
+        buildDunePackage rec {
+          pname = "sosa";
+          version = "0.3.0";
+
+          minimumOCamlVersion = "4.03";
+
+          src = fetchFromGitHub {
+            owner = "hammerlab";
+            repo = "${pname}";
+            rev = "${pname}.${version}";
+            sha256 = "053hdv6ww0q4mivajj4iyp7krfvgq8zajq9d8x4mia4lid7j0dyk";
+          };
+
+          buildInputs = [ ocamlbuild ];
+          buildPhase = "make build";
+          installPhase = ''
+            mkdir -p $out/lib/ocaml/4.07.1/site-lib
+            make install
+          '';
+          doCheck = false;
+        }) { };
+    genspio = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, nonstd, sosa, base }:
+
+        buildDunePackage rec {
+          pname = "genspio";
+          version = "0.0.2";
+
+          minimumOCamlVersion = "4.03";
+
+          src = fetchFromGitHub {
+            owner = "hammerlab";
+            repo = "${pname}";
+            rev = "genspio.${version}";
+            sha256 = "0cp6p1f713sfv4p2r03bzvjvakzn4ili7hf3a952b3w1k39hv37x";
+          };
+          propagatedBuildInputs = [ nonstd sosa ];
+          configurePhase = "ocaml please.mlt configure";
+          doCheck = false;
+        }) { };
+    dum = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, easy-format }:
+
+        buildDunePackage rec {
+          pname = "dum";
+          version = "1.0.1";
+
+          minimumOCamlVersion = "4.03";
+          buildPhase = "";
+          installPhase = ''
+            mkdir -p $out/lib/ocaml/4.07.1/site-lib
+            make install
+          '';
+
+          src = fetchFromGitHub {
+            owner = "mjambon";
+            repo = "${pname}";
+            rev = "v${version}";
+            sha256 = "0yrxl97szjc0s2ghngs346x3y0xszx2chidgzxk93frjjpsr1mlr";
+          };
+
+          buildInputs = [ easy-format ];
+          doCheck = false;
+        }) { };
+    hidapi = self.callPackage ({ stdenv, fetchFromGitHub, buildDunePackage
+      , hidapi, bigstring, pkg-config }:
+
+      buildDunePackage rec {
+        pname = "hidapi";
+        version = "1.1.1";
+
+        minimumOCamlVersion = "4.03";
+
+        src = fetchFromGitHub {
+          owner = "vbmithr";
+          repo = "ocaml-${pname}";
+          rev = version;
+          sha256 = "1qhc8iby3i54zflbi3yrnhpg62pwdl6g2sfnykgashjy7ghh495y";
+        };
+
+        buildInputs = [ bigstring hidapi pkg-config ];
+        doCheck = true;
+      }) { hidapi = pkgs.hidapi; };
+    ocamlgraph = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage }:
+
+        buildDunePackage rec {
+          pname = "ocamlgraph";
+          version = "1.8.8";
+
+          minimumOCamlmVersion = "4.03";
+
+          src = builtins.fetchTarball {
+            url = "http://ocamlgraph.lri.fr/download/ocamlgraph-1.8.8.tar.gz";
+            sha256 = "0xly2ckq9wy8pkszppcqv1bqb2yl2arij8f6n07bfiyaxh22crpq";
+          };
+          buildPhase = ''
+            chmod +x configure
+            ./configure
+            make
+          '';
+          installPhase = ''
+            mkdir -p $out/lib/ocaml/4.07.1/site-lib
+            make install-findlib
+          '';
+
+          buildInputs = [ ];
+          propagatedBuildInputs = [ ];
+          doCheck = false;
+        }) { };
+    irmin = self.callPackage ({ stdenv, fetchFromGitHub, buildDunePackage, fmt
+      , uri, jsonm, lwt4, logs, base64, digestif, ocamlgraph, astring, hex
+      , alcotest }:
+
+      buildDunePackage rec {
+        pname = "irmin";
+        version = "1.4.0";
+
+        minimumOCamlVersion = "4.03";
+
+        src = fetchFromGitHub {
+          owner = "mirage";
+          repo = pname;
+          rev = version;
+          sha256 = "0f272h9d0hs0wn5m30348wx7vz7524yk40wx5lx895vv3r3p7q7c";
+        };
+        buildInputs = [ fmt uri jsonm lwt4 base64 logs astring hex alcotest ];
+        propagatedBuildInputs = [ ocamlgraph digestif ];
+        doCheck = true;
+      }) { };
+
+    ipaddr = super.ipaddr.overrideDerivation (o: rec {
+      version = "4.0.0";
+      src = pkgs.fetchFromGitHub {
+        owner = "mirage";
+        repo = "ocaml-${o.pname}";
+        rev = "v${version}";
+        sha256 = "1ywhabdji7hqrmr07dcxlsxf5zndagrdxx378csi5bv3c5n9547z";
+      };
+      buildPhase = "dune build -p ipaddr,macaddr,ipaddr-sexp";
+      propagatedBuildInputs = o.propagatedBuildInputs ++ [ self.domain-name ];
+    });
+    conduit = super.conduit.overrideDerivation (o: rec {
+      version = "2.0.1";
+      src = pkgs.fetchFromGitHub {
+        owner = "mirage";
+        repo = "ocaml-${o.pname}";
+        rev = "v${version}";
+        sha256 = "0v4lxc6g9mavx8nk7djzsvx1blw5wsjn2cg6k6a35fyv64xmwd73";
+      };
+      propagatedBuildInputs = o.propagatedBuildInputs ++ [ self.sexplib ];
+    });
+    conduit-lwt-unix = super.conduit-lwt-unix.overrideDerivation (o: rec {
+      version = "2.0.1";
+      src = pkgs.fetchFromGitHub {
+        owner = "mirage";
+        repo = "ocaml-conduit";
+        rev = "v${version}";
+        sha256 = "0v4lxc6g9mavx8nk7djzsvx1blw5wsjn2cg6k6a35fyv64xmwd73";
+      };
+      propagatedBuildInputs = [ self.conduit-lwt self.logs self.tls ];
+    });
+    cohttp = super.cohttp.overrideDerivation (o: rec {
+      version = "2.3.0";
+      name = "cohttp-2.3.0";
+      src = pkgs.fetchFromGitHub {
+        owner = "mirage";
+        repo = "ocaml-${o.pname}";
+        rev = "v${version}";
+        sha256 = "0fag9zhv1lhbq1p4p1cmbav009x2d79kq3iv04pisj5y071qhhvr";
+      };
+      propagatedBuildInputs = o.propagatedBuildInputs ++ [ self.stdlib-shims ];
+    });
+    domain-name = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, fmt, astring }:
+        buildDunePackage rec {
+          pname = "domain-name";
+          version = "0.3.0";
+          src = pkgs.fetchFromGitHub {
+            owner = "hannesm";
+            repo = "${pname}";
+            rev = "v${version}";
+            sha256 = "06l82k27wa446k0sd799i73rrqwwmqfm542blkx6bbm2xpxaz2cm";
+          };
+          propagatedBuildInputs = [ fmt astring ];
+        }) { };
+
+    tezos = self.callPackage ({ stdenv, fetchgit, buildDunePackage, base
+      , bigstring, cohttp-lwt, cohttp-lwt-unix, cstruct, ezjsonm, hex, ipaddr
+      , js_of_ocaml, cmdliner, easy-format, ocp-ocamlres, tls, lwt4, lwt_log
+      , mtime, ocplib-endian, ptime, re, rresult, stdio, uri, uutf, zarith
+      , libusb1, hidapi, gmp, irmin, alcotest, dum, genspio, pprint, ocamlgraph
+      , findlib, digestif }:
+      buildDunePackage rec {
+        pname = "tezos";
+        version = "0.0.1";
+
+        minimumOCamlVersion = "4.07";
+
+        #src = ./.;
+        #patches = [ ./fix.patch ]; # babylonnet
+        patches = [ ./fix-mainnet.patch ];
+        src = fetchgit {
+          url = "https://gitlab.com/tezos/tezos.git/";
+          # babylonnet:
+          #rev = "b8731913f21091e14dea9c2b6657e768c1342650";
+          #sha256 = "1pakf1s6bg76fq42mb8fj1immz9g9wwimd522cpx8k28zf0hkl5i";
+          # mainnet:
+          rev = "94f779a7517f04d1786d710b0b8deea7a9c1f762";
+          sha256 = "16lxilng5q8fr2ll6h4hf7wlvac6nmw4cx10cbgzj5ks090bl97r";
+        };
+        preInstall = ''
+          cp src/*/*.install .
+        '';
+
+        buildInputs = [
+          base
+          bigstring
+          cohttp-lwt
+          cohttp-lwt-unix
+          cstruct
+          ezjsonm
+          irmin
+          hex
+          ipaddr # rmin
+          hidapi
+          lwt4
+          lwt_log
+          mtime
+          ocplib-endian
+          ptime
+          re
+          rresult
+          digestif
+          stdio
+          uri
+          uutf
+          zarith # cmdliner easy-format js_of_ocaml ocp-ocamlres tls
+          # alcotest dum pprint
+          ocamlgraph
+          findlib
+          genspio
+        ] ++ [ libusb1 libusb1.out (gmp.override { withStatic = true; }) ];
+        doCheck = false;
+        buildPhase = "dune build src/bin_client/tezos-client.install";
+        installPhase = ''
+          mkdir -p $out/bin
+          cp _build/default/src/bin_client/main_client.exe $out/bin/tezos-client
+          cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-admin
+        '';
+      }) { };
+  });
+in oca.tezos

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+diff --git a/src/bin_client/dune b/src/bin_client/dune
+index f42b53e6..7e47c074 100644
+--- a/src/bin_client/dune
++++ b/src/bin_client/dune
+@@ -28,7 +28,10 @@
+                     -open Tezos_client_base
+                     -open Tezos_client_commands
+                     -open Tezos_client_base_unix
+-                    -linkall)))
++                    -linkall
++                    -ccopt -static
++                    -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                    )))
+ 
+ (install
+  (section bin)
+diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
+index d9139c4b..a3af815c 100644
+--- a/src/lib_base/p2p_addr.ml
++++ b/src/lib_base/p2p_addr.ml
+@@ -36,8 +36,8 @@ let encoding =
+     end
+     ~binary:begin
+       conv
+-        Ipaddr.V6.to_bytes
+-        Ipaddr.V6.of_bytes_exn
++        Ipaddr.V6.to_octets
++        Ipaddr.V6.of_octets_exn
+         string
+     end
+ 
+diff --git a/src/lib_protocol_environment/tezos_protocol_environment.ml b/src/lib_protocol_environment/tezos_protocol_environment.ml
+index 14acf631..7b0efcd8 100644
+--- a/src/lib_protocol_environment/tezos_protocol_environment.ml
++++ b/src/lib_protocol_environment/tezos_protocol_environment.ml
+@@ -300,7 +300,7 @@ module MakeV1 (Param : sig val name: string end) () = struct
+     let to_bits ?(pad_to = 0) z =
+       let bits = to_bits z in
+       let len = Pervasives.((numbits z + 7) / 8) in
+-      let full_len = Compare.Int.max pad_to len in
++      let full_len = Stdlib.max pad_to len in
+       if full_len = 0 then
+         MBytes.empty
+       else

--- a/nix/fix.patch
+++ b/nix/fix.patch
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+diff --git a/src/bin_client/dune b/src/bin_client/dune
+index 6bee8e98..53006632 100644
+--- a/src/bin_client/dune
++++ b/src/bin_client/dune
+@@ -21,7 +21,10 @@
+                     -open Tezos_client_base
+                     -open Tezos_client_commands
+                     -open Tezos_client_base_unix
+-                    -linkall)))
++                    -linkall
++                    -ccopt -static
++                    -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                    )))
+ 
+ (install
+  (section bin)

--- a/nix/musl-bin.nix
+++ b/nix/musl-bin.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ stdenv, musl, netbsd }:
+let
+  getconf = builtins.fetchurl https://raw.githubusercontent.com/alpinelinux/aports/master/main/musl/getconf.c;
+  getent = builtins.fetchurl https://raw.githubusercontent.com/alpinelinux/aports/master/main/musl/getent.c;
+  isMusl = stdenv.hostPlatform.isMusl;
+in
+stdenv.mkDerivation {
+  pname = "musl-bin";
+  version = musl.version;
+  srcs = [
+    getconf
+    getent
+  ];
+  buildInputs = [ musl ];
+  unpackPhase = ''
+    cp $srcs .
+  '';
+  buildPhase = ''
+    ${if !isMusl then "musl-gcc" else "$CC"} *-getconf.c -o getconf
+    ${if !isMusl then "musl-gcc" else "$CC"} *-getent.c -o getent
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D ./getconf ./getent $out/bin
+  '';
+}

--- a/nix/static.nix
+++ b/nix/static.nix
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+let
+  fixOcaml = ocaml:
+    (ocaml.overrideAttrs (o: {
+      configurePlatforms = [ ];
+      dontUpdateAutotoolsGnuConfigScripts = true;
+    })).overrideDerivation (o:
+      if o.stdenv.hostPlatform != o.stdenv.buildPlatform then {
+        preConfigure = ''
+          configureFlagsArray+=("-cc" "$CC" "-as" "$AS" "-partialld" "$LD -r")
+        '';
+        configureFlags = o.configureFlags ++ [
+          "-host ${o.stdenv.hostPlatform.config} -target ${o.stdenv.targetPlatform.config}"
+        ];
+      } else
+        { });
+  fixOcamlBuild = b:
+    b.overrideAttrs (o: {
+      configurePlatforms = [ ];
+      nativeBuildInputs = o.buildInputs;
+    });
+  dds = x: x.overrideAttrs (o: { dontDisableStatic = true; });
+  nixpkgs-fixed = builtins.fetchTarball
+    "https://github.com/serokell/nixpkgs/archive/ocaml-cross-fixes.tar.gz";
+  pkgsNative = import nixpkgs-fixed { };
+  pkgs = import nixpkgs-fixed {
+    crossSystem = pkgsNative.lib.systems.examples.musl64;
+    overlays = [
+      (self: super: { ocaml = fixOcaml super.ocaml; })
+      (self: super: {
+        musl-bin = super.callPackage ./musl-bin.nix { };
+        getent = self.musl-bin;
+        getconf = self.musl-bin;
+        libev = dds super.libev;
+        libusb1 = dds (super.libusb1.override { systemd = self.eudev; });
+        hidapi = dds (super.hidapi.override { systemd = self.eudev; });
+        glib = (super.glib.override { libselinux = null; }).overrideAttrs
+          (o: { mesonFlags = o.mesonFlags ++ [ "-Dselinux=disabled" ]; });
+        eudev = dds (super.eudev.overrideAttrs
+          (o: { nativeBuildInputs = o.nativeBuildInputs ++ [ super.gperf ]; }));
+        opaline = fixOcamlBuild (super.opaline.override {
+          ocamlPackages = self.ocaml-ng.ocamlPackages_4_07;
+        });
+        ocaml-ng = super.ocaml-ng // {
+          ocamlPackages_4_07 = super.ocaml-ng.ocamlPackages_4_07.overrideScope'
+            (oself: osuper: {
+              ocaml = fixOcaml osuper.ocaml;
+              findlib = fixOcamlBuild osuper.findlib;
+              ocamlbuild = fixOcamlBuild osuper.ocamlbuild;
+              buildDunePackage = args:
+                fixOcamlBuild (osuper.buildDunePackage args);
+              result = fixOcamlBuild osuper.result;
+              zarith = (osuper.zarith.overrideAttrs (o: {
+                configurePlatforms = [ ];
+                nativeBuildInputs = o.nativeBuildInputs ++ o.buildInputs;
+              })).overrideDerivation (o: {
+                preConfigure = ''
+                  echo $configureFlags
+                '';
+                configureFlags = o.configureFlags ++ [
+                  "-host ${o.stdenv.hostPlatform.config} -prefixnonocaml ${o.stdenv.hostPlatform.config}-"
+                ];
+              });
+              ocamlgraph = fixOcamlBuild osuper.ocamlgraph;
+              easy-format = fixOcamlBuild osuper.easy-format;
+              qcheck = fixOcamlBuild osuper.qcheck;
+              stringext = fixOcamlBuild osuper.stringext;
+              opam-file-format = fixOcamlBuild osuper.opam-file-format;
+              dune = fixOcamlBuild osuper.dune;
+              digestif = fixOcamlBuild osuper.digestif;
+              astring = fixOcamlBuild osuper.astring;
+              rresult = fixOcamlBuild osuper.rresult;
+              fpath = fixOcamlBuild osuper.fpath;
+              ocb-stubblr = fixOcamlBuild osuper.ocb-stubblr;
+              cppo = fixOcamlBuild osuper.cppo;
+              ocplib-endian = fixOcamlBuild osuper.ocplib-endian;
+              ssl = fixOcamlBuild osuper.ssl;
+            });
+        };
+      })
+    ];
+  };
+in import ./default.nix { inherit pkgs; }

--- a/packageDeb.nix
+++ b/packageDeb.nix
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ stdenv, writeTextFile }:
+pkgDesc:
+
+let
+  project = pkgDesc.project;
+  majorVersion = pkgDesc.majorVersion;
+  minorVersion = pkgDesc.minorVersion;
+  pkgRevision = pkgDesc.packageRevision;
+  bin = pkgDesc.bin;
+  pkgName = "${project}_${majorVersion}.${minorVersion}-${pkgRevision}";
+
+  writeControlFile = writeTextFile {
+    name = "control";
+    text = ''
+      Package: ${project}
+      Version: ${majorVersion}.${minorVersion}-${pkgRevision}
+      Priority: optional
+      Architecture: ${pkgDesc.arch}
+      Depends: ${pkgDesc.dependencies}
+      Maintainer: ${pkgDesc.maintainer}
+      Description: ${project}
+       ${pkgDesc.description}
+    '';
+  };
+
+in rec {
+  packageDeb =
+    stdenv.mkDerivation {
+      name = "${pkgName}.deb";
+
+      phases = "packagePhase";
+
+      packagePhase = ''
+        mkdir ${pkgName}
+        mkdir -p ${pkgName}/usr/local/bin
+        cp ${bin} ${pkgName}/usr/local/bin/${project}
+
+        mkdir ${pkgName}/DEBIAN
+        cp ${writeControlFile} ${pkgName}/DEBIAN/control
+
+        dpkg-deb --build ${pkgName}
+        mv ${pkgName}.deb $out
+      '';
+    };
+}

--- a/packageRpm.nix
+++ b/packageRpm.nix
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ stdenv, writeTextFile }:
+pkgDesc:
+
+let
+  project = pkgDesc.project;
+  majorVersion = pkgDesc.majorVersion;
+  minorVersion = pkgDesc.minorVersion;
+  pkgRevision = pkgDesc.packageRevision;
+  arch = pkgDesc.arch;
+  bin = pkgDesc.bin;
+  pkgName = "${project}-${majorVersion}.${minorVersion}-${pkgRevision}.${arch}";
+  licenseFile = pkgDesc.licenseFile;
+
+  writeSpecFile = writeTextFile {
+    name = "${project}.spec";
+    text = ''
+      Name:    ${project}
+      Release: ${pkgRevision}
+      Summary: ${pkgDesc.description}
+      License: ${pkgDesc.license}
+      Version: ${majorVersion}.${minorVersion}
+
+      %description
+      CLI executable that can be used for managing deployed TZBTC contract
+
+      %files
+      /usr/local/bin/${project}
+      %doc %name-%version/LICENSE
+    '';
+  };
+
+in rec {
+  packageRpm =
+    stdenv.mkDerivation {
+      name = "${pkgName}.rpm";
+
+      phases = "packagePhase";
+
+      packagePhase = ''
+        HOME=$PWD
+        mkdir rpmbuild
+        cd rpmbuild
+        mkdir SPECS
+        cp ${writeSpecFile} SPECS/${project}.spec
+        mkdir -p BUILD/${project}-${majorVersion}.${minorVersion}
+        cp ${licenseFile} BUILD/${project}-${majorVersion}.${minorVersion}/LICENSE
+
+        mkdir -p BUILDROOT/${pkgName}/usr/local/bin
+        cp ${bin} BUILDROOT/${pkgName}/usr/local/bin/${project}
+
+        rpmbuild -bb SPECS/${project}.spec
+        cp RPMS/${arch}/${pkgName}.rpm $out
+      '';
+
+    };
+}


### PR DESCRIPTION
We have nix expressions for building static `tezos-client` binary. Having this executable separate
from the `babylonnet.sh` or `mainnet.sh` scripts will be useful for tezos community.

This PR provides initial repository set up with instructions on how to build static `tezos-client` binary and
`.rpm/deb` packages based on this binary. Also set up CI to produce these packages and binary.